### PR TITLE
fixes for rfdiffusion imports, readme, and RF2 model path

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,15 +142,16 @@ The first step in RFantibody is to generate antibody-target docks using an antib
 ```
 # From inside of the rfantibody container
 
-poetry run python  /home/src/rfantibody/scripts/rfdiffusion_inference.py \
-    --config-name antibody \
-    antibody.target_pdb=/home/scripts/examples/example_inputs/rsv_site3.pdb \
-    antibody.framework_pdb=/home/scripts/examples/example_inputs/hu-4D5-8_Fv.pdb \
-    inference.ckpt_override_path=/home/weights/RFdiffusion_Ab.pt \
-    'ppi.hotspot_res=[T305,T456]' \
-    'antibody.design_loops=[L1:8-13,L2:7,L3:9-11,H1:7,H2:6,H3:5-13]' \
-    inference.num_designs=20 \
-    inference.output_prefix=/home/scripts/examples/example_outputs/ab_des
+poetry run python  /home/scripts/rfdiffusion_inference.py \
+  --config-path /home/src/rfantibody/rfdiffusion/config/inference \
+  --config-name antibody \
+  antibody.target_pdb=/home/scripts/examples/example_inputs/rsv_site3.pdb \
+  antibody.framework_pdb=/home/scripts/examples/example_inputs/hu-4D5-8_Fv.pdb \
+  inference.ckpt_override_path=/home/weights/RFdiffusion_Ab.pt \
+  'ppi.hotspot_res=[T305,T456]' \
+  'antibody.design_loops=[L1:8-13,L2:7,L3:9-11,H1:7,H2:6,H3:5-13]' \
+  inference.num_designs=20 \
+  inference.output_prefix=/home/scripts/examples/example_outputs/ab_des
 ```
 
 Let's go through this command in more detail to understand what these configs are doing:

--- a/src/rfantibody/rf2/network/predict.py
+++ b/src/rfantibody/rf2/network/predict.py
@@ -203,7 +203,7 @@ class Predictor():
         # define model name
         self.model_weights = model_weights
         if not os.path.exists(model_weights):
-            self.model_weights = os.path.dirname(__file__) + '/' + model_weights
+            self.model_weights = model_weights
 
         self.device = device
         self.active_fn = nn.Softmax(dim=1)

--- a/src/rfantibody/rfdiffusion/diff_util.py
+++ b/src/rfantibody/rfdiffusion/diff_util.py
@@ -2,7 +2,7 @@ import torch
 import numpy as np 
 import random 
 
-from chemical import INIT_CRDS
+from rfantibody.rfdiffusion.chemical import INIT_CRDS
 from icecream import ic 
 
 

--- a/src/rfantibody/rfdiffusion/diffusion.py
+++ b/src/rfantibody/rfdiffusion/diffusion.py
@@ -8,20 +8,20 @@ from typing import List
 
 from scipy.spatial.transform import Rotation as scipy_R
 from scipy.spatial.transform import Slerp 
-import rotation_conversions
+from rfantibody.rfdiffusion import rotation_conversions
 
-from util import rigid_from_3_points, get_torsions
+from rfantibody.rfdiffusion.util import rigid_from_3_points, get_torsions
 
-from util import torsion_indices as TOR_INDICES 
-from util import torsion_can_flip as TOR_CAN_FLIP
-from util import reference_angles as REF_ANGLES
+from rfantibody.rfdiffusion.util import torsion_indices as TOR_INDICES 
+from rfantibody.rfdiffusion.util import torsion_can_flip as TOR_CAN_FLIP
+from rfantibody.rfdiffusion.util import reference_angles as REF_ANGLES
 
-from util_module import ComputeAllAtomCoords
+from rfantibody.rfdiffusion.util_module import ComputeAllAtomCoords
 
-from diff_util import th_min_angle, th_interpolate_angles, get_aa_schedule 
+from rfantibody.rfdiffusion.diff_util import th_min_angle, th_interpolate_angles, get_aa_schedule 
 
-from chemical import INIT_CRDS 
-import igso3
+from rfantibody.rfdiffusion.chemical import INIT_CRDS 
+from rfantibody.rfdiffusion import igso3
 import time 
 
 from icecream import ic  

--- a/src/rfantibody/rfdiffusion/inference/ab_pose.py
+++ b/src/rfantibody/rfdiffusion/inference/ab_pose.py
@@ -3,12 +3,12 @@ import os
 import sys
 import torch
 from icecream import ic
-from parsers import chothia_pdb_parser, HLT_pdb_parser
+from rfantibody.rfdiffusion.parsers import chothia_pdb_parser, HLT_pdb_parser
 
-from chemical import INIT_CRDS
+from rfantibody.rfdiffusion.chemical import INIT_CRDS
 import random
-from util import Dotdict
-from inference.utils import parse_pdb
+from rfantibody.rfdiffusion.util import Dotdict
+from rfantibody.rfdiffusion.inference.utils import parse_pdb
 
 def idx2int(idx:str) -> int:
     '''

--- a/src/rfantibody/rfdiffusion/inference/utils.py
+++ b/src/rfantibody/rfdiffusion/inference/utils.py
@@ -2,22 +2,22 @@ import numpy as np
 import os
 import sys
 from omegaconf import DictConfig
-from kinematics import xyz_to_t2d
+from rfantibody.rfdiffusion.kinematics import xyz_to_t2d
 import torch
 import torch.nn.functional as nn
-from util import get_torsions
-from diffusion import get_beta_schedule, get_aa_schedule, get_chi_betaT
-from diff_util import get_aa_schedule, th_interpolate_angles, th_min_angle, th_interpolate_angle_single
+from rfantibody.rfdiffusion.util import get_torsions
+from rfantibody.rfdiffusion.diffusion import get_beta_schedule, get_aa_schedule, get_chi_betaT
+from rfantibody.rfdiffusion.diff_util import get_aa_schedule, th_interpolate_angles, th_min_angle, th_interpolate_angle_single
 from icecream import ic
 from scipy.spatial.transform import Rotation as scipy_R
 from scipy.spatial.transform import Slerp
-from util import torsion_indices as TOR_INDICES
-from util import torsion_can_flip as TOR_CAN_FLIP
-from util import reference_angles as REF_ANGLES
-from util import rigid_from_3_points
-from util_module import ComputeAllAtomCoords
-from potentials.manager import PotentialManager
-import util
+from rfantibody.rfdiffusion.util import torsion_indices as TOR_INDICES
+from rfantibody.rfdiffusion.util import torsion_can_flip as TOR_CAN_FLIP
+from rfantibody.rfdiffusion.util import reference_angles as REF_ANGLES
+from rfantibody.rfdiffusion.util import rigid_from_3_points
+from rfantibody.rfdiffusion.util_module import ComputeAllAtomCoords
+from rfantibody.rfdiffusion.potentials.manager import PotentialManager
+from rfantibody.rfdiffusion import util
 import random
 import logging
 import string 

--- a/src/rfantibody/rfdiffusion/parsers.py
+++ b/src/rfantibody/rfdiffusion/parsers.py
@@ -6,11 +6,11 @@ import numpy as np
 import string
 import os,re
 import random
-import util
+
 import gzip
 
 import pandas as pd
-
+from rfantibody.rfdiffusion import util 
 from rfantibody.rfdiffusion.chemical import aa2num, aa2long
 
 

--- a/src/rfantibody/rfdiffusion/potentials/potentials.py
+++ b/src/rfantibody/rfdiffusion/potentials/potentials.py
@@ -1,7 +1,7 @@
 import torch
 from icecream import ic 
 import numpy as np 
-from util import generate_Cbeta
+from rfantibody.rfdiffusion.util import generate_Cbeta
 from icecream import ic
 
 class Potential:


### PR DESCRIPTION
This PR Addresses a few issues we encountered while following the readme to install and run the RFAntibody pipeline. Specifically:

* Correcting the path for the rf_diffusion_inference.py command in the README and adding a `--config-path` override so that the correct path to the config directory is specified
* fixing `src/rfantibody/rf2/network/predict.py` so that the provided `model.model_weights` path is not appended to the location of the predict.py file
* converting relative imports to absolute imports in `rfantibody.rfdiffusion` so that `rf_diffusion_inference.py` runs properly regardless of where in the filesystem the user executes it. 