### PR TITLE
Adding dockerfile suitable for production use

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,17 @@ This does the following:
 - Use [Python Poetry](https://python-poetry.org) to build the Python environment
 - Build the [USalign](https://github.com/pylelab/USalign) executable
 
+## Production Docker Image
+
+process described above is well suited for development.  However, if you are deploying the RFAntibody pipeline to a production environment, it is better to have a docker image with all dependencies pre-installed.  The `production.Dockerfile` Dockerfile accomplishes this. It builds an image with all dependencies installed.  The RFAntibody source and scripts are installed in `/opt/rfantibody`.
+
+### Building production Docker Image
+
+```
+docker build -t rfantibody-production -f production.Dockerfile.
+```
+
+
 # Usage
 
 ## HLT File Format
@@ -142,6 +153,7 @@ The first step in RFantibody is to generate antibody-target docks using an antib
 ```
 # From inside of the rfantibody container
 
+<<<<<<< HEAD
 poetry run python  /home/src/rfantibody/scripts/rfdiffusion_inference.py \
     --config-name antibody \
     antibody.target_pdb=/home/scripts/examples/example_inputs/rsv_site3.pdb \
@@ -151,6 +163,18 @@ poetry run python  /home/src/rfantibody/scripts/rfdiffusion_inference.py \
     'antibody.design_loops=[L1:8-13,L2:7,L3:9-11,H1:7,H2:6,H3:5-13]' \
     inference.num_designs=20 \
     inference.output_prefix=/home/scripts/examples/example_outputs/ab_des
+=======
+poetry run python  /opt/rfantibody/scripts/rfdiffusion_inference.py \
+  --config-path /opt/rfantibody/src/rfantibody/rfdiffusion/config/inference \
+  --config-name antibody \
+  antibody.target_pdb=/home/scripts/examples/example_inputs/rsv_site3.pdb \
+  antibody.framework_pdb=/home/scripts/examples/example_inputs/hu-4D5-8_Fv.pdb \
+  inference.ckpt_override_path=/home/weights/RFdiffusion_Ab.pt \
+  'ppi.hotspot_res=[T305,T456]' \
+  'antibody.design_loops=[L1:8-13,L2:7,L3:9-11,H1:7,H2:6,H3:5-13]' \
+  inference.num_designs=20 \
+  inference.output_prefix=/home/scripts/examples/example_outputs/ab_des
+>>>>>>> 010a498 (Adding dockerfile suitable for production use)
 ```
 
 Let's go through this command in more detail to understand what these configs are doing:

--- a/production.Dockerfile
+++ b/production.Dockerfile
@@ -1,0 +1,28 @@
+FROM nvidia/cuda:11.8.0-cudnn8-devel-ubuntu22.04
+ARG DEBIAN_FRONTEND=noninteractive
+
+COPY src /opt/rfantibody/src
+COPY scripts /opt/rfantibody/scripts
+COPY include/USalign /opt/rfantibody/include/USalign
+COPY include/SE3Transformer /opt/rfantibody/include/SE3Transformer
+COPY poetry.lock /opt/rfantibody/poetry.lock
+COPY pyproject.toml /opt/rfantibody/pyproject.toml
+COPY README.md /opt/rfantibody/README.md
+
+RUN apt-get update && apt-get install -y software-properties-common && \
+    DEBIAN_FRONTEND=noninteractive add-apt-repository -y ppa:deadsnakes/ppa && \
+    apt-get install --no-install-recommends -y python3.10 python3-pip pipx vim make wget
+
+RUN alias "python"="python3.10"
+
+RUN pip install poetry
+RUN mkdir /opt/rfantibody/include/dgl
+RUN wget -O /opt/rfantibody/include/dgl/dgl-2.4.0+cu118-cp310-cp310-manylinux1_x86_64.whl https://data.dgl.ai/wheels/torch-2.3/cu118/dgl-2.4.0%2Bcu118-cp310-cp310-manylinux1_x86_64.whl
+
+WORKDIR /opt/rfantibody/include/USalign
+RUN make
+
+WORKDIR /opt/rfantibody
+RUN poetry install
+
+ENTRYPOINT /bin/bash


### PR DESCRIPTION
This PR adds a Dockerfile which installs all dependencies and the RFAntibody source during build, generating an image better suited to deployment in a production environment than the default docker image. 