### PR TITLE
explicitly adding dim argument to torch.cross

### DIFF
--- a/src/rfantibody/rfdiffusion/util.py
+++ b/src/rfantibody/rfdiffusion/util.py
@@ -220,7 +220,7 @@ def make_frame(X, Y):
     Xn = X / torch.linalg.norm(X)
     Y = Y - torch.dot(Y, Xn) * Xn
     Yn = Y / torch.linalg.norm(Y)
-    Z = torch.cross(Xn,Yn)
+    Z = torch.cross(Xn,Yn,dim=-1)
     Zn =  Z / torch.linalg.norm(Z)
 
     return torch.stack((Xn,Yn,Zn), dim=-1)


### PR DESCRIPTION
There is a user warning of a deprecation for torch.cross. This tiny change fixes that to avoid unintended behavior in the future:
```
UserWarning: Using torch.cross without specifying the dim arg is deprecated.
Please either pass the dim explicitly or simply use torch.linalg.cross.
The default value of dim will change to agree with that of linalg.cross in a future release. (Triggered internally at ../aten/src/ATen/native/Cross.cpp:62.)
```