### PR TITLE
installtion on read only file system

### DIFF
--- a/scripts/config/inference/antibody.yaml
+++ b/scripts/config/inference/antibody.yaml
@@ -21,3 +21,10 @@ antibody:
   terminate_bad_targeting: null
   hotspot_termination_threshold: 10
   hotspot_termination_failures_permitted: 20
+
+hydra:
+  run:
+    dir: ${oc.env:HOME}/.rfantibody/outputs/${now:%Y-%m-%d}/${now:%H-%M-%S}
+  sweep:
+    dir: ${oc.env:HOME}/.rfantibody/multirun/${now:%Y-%m-%d}/${now:%H-%M-%S}
+    subdir: ${hydra.job.num}

--- a/scripts/config/inference/base.yaml
+++ b/scripts/config/inference/base.yaml
@@ -168,3 +168,10 @@ scaffoldguided:
   target_ss: null
   target_adj: null
   mask_loops: True
+
+hydra:
+  run:
+    dir: ${oc.env:HOME}/.rfantibody/outputs/${now:%Y-%m-%d}/${now:%H-%M-%S}
+  sweep:
+    dir: ${oc.env:HOME}/.rfantibody/multirun/${now:%Y-%m-%d}/${now:%H-%M-%S}
+    subdir: ${hydra.job.num}

--- a/src/rfantibody/cli/inference.py
+++ b/src/rfantibody/cli/inference.py
@@ -100,7 +100,7 @@ def rfdiffusion(
         sys.exit(1)
 
     # Build command
-    cmd = [sys.executable, str(script_path), '--config-name', 'antibody']
+    cmd = ['python', str(script_path), '--config-name', 'antibody']
 
     # Required parameters
     cmd.append(f'antibody.target_pdb={target}')
@@ -246,7 +246,7 @@ def proteinmpnn(
         sys.exit(1)
 
     # Build command
-    cmd = [sys.executable, str(script_path)]
+    cmd = ['python', str(script_path)]
 
     # Input
     if input_dir:
@@ -394,7 +394,7 @@ def rf2(
         sys.exit(1)
 
     # Build command
-    cmd = [sys.executable, str(script_path)]
+    cmd = ['python', str(script_path)]
 
     # Input
     if input_pdb:

--- a/src/rfantibody/cli/inference.py
+++ b/src/rfantibody/cli/inference.py
@@ -100,7 +100,7 @@ def rfdiffusion(
         sys.exit(1)
 
     # Build command
-    cmd = ['python', str(script_path), '--config-name', 'antibody']
+    cmd = [sys.executable, str(script_path), '--config-name', 'antibody']
 
     # Required parameters
     cmd.append(f'antibody.target_pdb={target}')
@@ -246,7 +246,7 @@ def proteinmpnn(
         sys.exit(1)
 
     # Build command
-    cmd = ['python', str(script_path)]
+    cmd = [sys.executable, str(script_path)]
 
     # Input
     if input_dir:
@@ -394,7 +394,7 @@ def rf2(
         sys.exit(1)
 
     # Build command
-    cmd = ['python', str(script_path)]
+    cmd = [sys.executable, str(script_path)]
 
     # Input
     if input_pdb:

--- a/src/rfantibody/rf2/config/base.yaml
+++ b/src/rfantibody/rf2/config/base.yaml
@@ -54,3 +54,9 @@ model_param:
     div: 4
     n_heads: 4
 
+hydra:
+  run:
+    dir: ${oc.env:HOME}/.rfantibody/outputs/${now:%Y-%m-%d}/${now:%H-%M-%S}
+  sweep:
+    dir: ${oc.env:HOME}/.rfantibody/multirun/${now:%Y-%m-%d}/${now:%H-%M-%S}
+    subdir: ${hydra.job.num}

--- a/src/rfantibody/rfdiffusion/diffusion.py
+++ b/src/rfantibody/rfdiffusion/diffusion.py
@@ -1,6 +1,7 @@
 # script for diffusion protocols 
 import logging
 import os
+from pathlib import Path
 import pickle
 import time
 from typing import List
@@ -49,8 +50,10 @@ def get_chi_betaT(max_timestep=100, beta_0=0.01, abar_T=1e-3, method='cosine'):
     Function to precalculate beta_T for chi angles (decoded at different time steps, so T in beta_T varies).
     Calculated empirically
     """
+    cache_dir=os.path.join(Path.home(), '.rfantibody', 'cached_schedules')
+    name = f'T{max_timestep}_beta_0{beta_0}_abar_T{abar_T}_method_{method}.pkl'
+    name=os.path.join(cache_dir, name)
 
-    name = f'./cached_schedules/T{max_timestep}_beta_0{beta_0}_abar_T{abar_T}_method_{method}.pkl'
 
     if not os.path.exists(name):
         print('Calculating chi_beta_T dictionary...')
@@ -72,8 +75,8 @@ def get_chi_betaT(max_timestep=100, beta_0=0.01, abar_T=1e-3, method='cosine'):
             beta_Ts[timestep] = idx.item()
 
         # save cached schedule
-        if not os.path.isdir('./cached_schedules/'):
-            os.makedirs('./cached_schedules/', exist_ok=True)
+        if not os.path.isdir(cache_dir):
+            os.makedirs(cache_dir, exist_ok=True)
         with open(name, 'wb') as fp:
             pickle.dump(beta_Ts, fp)
 
@@ -880,7 +883,7 @@ class Diffuser():
                  schedule_kwargs={},
                  chi_kwargs={},
                  var_scale=1.0,
-                 cache_dir='.',
+                 cache_dir=os.path.join(Path.home(), '.rfantibody', 'cached_schedules'),
                  partial_T=None,
                  truncation_level=2000
                  ):


### PR DESCRIPTION
Hello, 

we installed RFantiboy on our cluster on read only shared disk. and have problems with user trying to write files on this FS

our users hit some rights problem when the tools tries to writtes some hydra//omega `outputs` logs.
```
 PermissionError: [Errno 13] Permission denied: 'outputs/2026-04-17’ 
```

fixing this problem #a22641133c3584e02ff8e87b0cbc4d55f0f74df1 by settings hydra config to spit `outputs` to HOME/.rfantibody

but then we noticed an other problems, with `.pkl` file caching.

#2dba312c9c27e2094f48978f741c4d06a706ddab allow to also cache generated `.pkl` files to same destination than outputs. 

regards

Eric